### PR TITLE
Fix: ReadClusterNodeOutput.ClusterNodes[].WorkloadRequestedMemoryInMiB type issue

### DIFF
--- a/service/ocean/providers/aws/clusternodes.go
+++ b/service/ocean/providers/aws/clusternodes.go
@@ -22,7 +22,7 @@ type ClusterNodes struct {
 	NodeName                     *string  `json:"nodeName,omitempty"`
 	RegistrationStatus           *string  `json:"registrationStatus,omitempty"`
 	WorkloadRequestedMilliCpu    *int     `json:"workloadRequestedMilliCpu,omitempty"`
-	WorkloadRequestedMemoryInMiB *int     `json:"workloadRequestedMemoryInMiB,omitempty"`
+	WorkloadRequestedMemoryInMiB *float64 `json:"workloadRequestedMemoryInMiB,omitempty"`
 	WorkloadRequestedGpu         *int     `json:"workloadRequestedGpu,omitempty"`
 	HeadroomRequestedMilliCpu    *int     `json:"headroomRequestedMilliCpu,omitempty"`
 	HeadroomRequestedMemoryInMiB *int     `json:"headroomRequestedMemoryInMiB,omitempty"`


### PR DESCRIPTION
Changed type of workloadRequestedMemoryInMiB from *int to *float64

**Error**: 
`json: cannot unmarshal number 117224.4 into Go struct field ClusterNodes.workloadRequestedMemoryInMiB of type int`

**Function**: 
`ocean.ServiceOp.CloudProviderAWS().ReadClusterNodes(context.Context, *ReadClusterNodeInput) (*ReadClusterNodeOutput, error)`